### PR TITLE
feat: Add GridCollectionSection

### DIFF
--- a/BricksAndTiles.xcodeproj/project.pbxproj
+++ b/BricksAndTiles.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		59CA4F91251D09460096E22E /* GridCollectionSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CA4F90251D09460096E22E /* GridCollectionSection.swift */; };
+		59CA4F93251D0ED20096E22E /* CollectionViewGridExampleController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CA4F92251D0ED20096E22E /* CollectionViewGridExampleController.swift */; };
+		59CA4F95251D3DE90096E22E /* GridListFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CA4F94251D3DE90096E22E /* GridListFactory.swift */; };
 		731C9DF22503CA1500967DA4 /* MeetupExampleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731C9DF12503CA1500967DA4 /* MeetupExampleType.swift */; };
 		731C9DF52503CEB300967DA4 /* MeetupFactoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731C9DF42503CEB300967DA4 /* MeetupFactoryViewController.swift */; };
 		731C9E0325043E2A00967DA4 /* MeetupTableViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731C9E0225043E2A00967DA4 /* MeetupTableViewFactory.swift */; };
@@ -146,6 +149,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		59CA4F90251D09460096E22E /* GridCollectionSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridCollectionSection.swift; sourceTree = "<group>"; };
+		59CA4F92251D0ED20096E22E /* CollectionViewGridExampleController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewGridExampleController.swift; sourceTree = "<group>"; };
+		59CA4F94251D3DE90096E22E /* GridListFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridListFactory.swift; sourceTree = "<group>"; };
 		731C9DF12503CA1500967DA4 /* MeetupExampleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetupExampleType.swift; sourceTree = "<group>"; };
 		731C9DF42503CEB300967DA4 /* MeetupFactoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetupFactoryViewController.swift; sourceTree = "<group>"; };
 		731C9E0225043E2A00967DA4 /* MeetupTableViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetupTableViewFactory.swift; sourceTree = "<group>"; };
@@ -266,6 +272,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		59CA4F8F251D09130096E22E /* CollectionViewGridExample */ = {
+			isa = PBXGroup;
+			children = (
+				59CA4F92251D0ED20096E22E /* CollectionViewGridExampleController.swift */,
+				59CA4F94251D3DE90096E22E /* GridListFactory.swift */,
+			);
+			path = CollectionViewGridExample;
+			sourceTree = "<group>";
+		};
 		731C9DEE2503C82B00967DA4 /* MeetupExample */ = {
 			isa = PBXGroup;
 			children = (
@@ -407,6 +422,7 @@
 		73610D4524F1A8260070D724 /* Examples */ = {
 			isa = PBXGroup;
 			children = (
+				59CA4F8F251D09130096E22E /* CollectionViewGridExample */,
 				73610D5324F1A8260070D724 /* GenericExamplePresenter.swift */,
 				73610D4B24F1A8260070D724 /* GenericExampleViewController.swift */,
 				73610D5924F1A8260070D724 /* AlternateStaticExample */,
@@ -611,6 +627,7 @@
 			children = (
 				736E6B9224B21B7C0086B985 /* CollectionViewSection.swift */,
 				73B8FB2024D394F900B32167 /* StaticCollectionSection.swift */,
+				59CA4F90251D09460096E22E /* GridCollectionSection.swift */,
 			);
 			path = Sections;
 			sourceTree = "<group>";
@@ -971,6 +988,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73610D7A24F1A8270070D724 /* SingleSelectionTableViewCell.swift in Sources */,
+				59CA4F93251D0ED20096E22E /* CollectionViewGridExampleController.swift in Sources */,
 				73610D8524F1A8270070D724 /* DraggableExampleTableViewFactory.swift in Sources */,
 				73610D8024F1A8270070D724 /* FirstStaticCell.swift in Sources */,
 				73610D7224F1A8270070D724 /* GenericExampleViewController.swift in Sources */,
@@ -1011,6 +1029,7 @@
 				731C9E0525043E8000967DA4 /* MeetupTableViewFactoryState.swift in Sources */,
 				73610D7624F1A8270070D724 /* HorizontalCell.swift in Sources */,
 				73610D2824F16B710070D724 /* ExampleListPresenter.swift in Sources */,
+				59CA4F95251D3DE90096E22E /* GridListFactory.swift in Sources */,
 				731C9E0F2504442B00967DA4 /* MeetupAlbumCellBuilder.swift in Sources */,
 				73610D1E24F16B710070D724 /* AppDelegate.swift in Sources */,
 				73610D8624F1A8270070D724 /* DragableExampleCellBuilder.swift in Sources */,
@@ -1035,6 +1054,7 @@
 				EBF15B02229B3AD20055DF69 /* TableViewDataSource.swift in Sources */,
 				73B8FB2124D394F900B32167 /* StaticCollectionSection.swift in Sources */,
 				73B8FB2324D3957A00B32167 /* CollectionViewCellBuilder.swift in Sources */,
+				59CA4F91251D09460096E22E /* GridCollectionSection.swift in Sources */,
 				736E6B8D24B219AF0086B985 /* CollectionViewDataSource.swift in Sources */,
 				EBF15B11229B3B190055DF69 /* TableViewCellBuilder.swift in Sources */,
 				EBF15B04229B3AD20055DF69 /* TableViewItem.swift in Sources */,

--- a/BricksAndTiles/Source/CollectionView/CollectionViewDataSource.swift
+++ b/BricksAndTiles/Source/CollectionView/CollectionViewDataSource.swift
@@ -80,4 +80,34 @@ extension CollectionViewDataSource: UICollectionViewDelegateFlowLayout {
             layout: collectionViewLayout
         )
     }
+
+    public func collectionView(_ collectionView: UICollectionView,
+                               layout collectionViewLayout: UICollectionViewLayout,
+                               insetForSectionAt section: Int) -> UIEdgeInsets {
+        return sections[section].sectionBorderEdges(
+            at: section,
+            on: collectionView,
+            layout: collectionViewLayout
+        )
+    }
+
+    public func collectionView(_ collectionView: UICollectionView,
+                               layout collectionViewLayout: UICollectionViewLayout,
+                               minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return sections[section].minimumVerticalItemSpacing(
+            at: section,
+            on: collectionView,
+            layout: collectionViewLayout
+        )
+    }
+
+    public func collectionView(_ collectionView: UICollectionView,
+                               layout collectionViewLayout: UICollectionViewLayout,
+                               minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return sections[section].minimumHorizontalItemSpacing(
+            at: section,
+            on: collectionView,
+            layout: collectionViewLayout
+        )
+    }
 }

--- a/BricksAndTiles/Source/CollectionView/Sections/CollectionViewSection.swift
+++ b/BricksAndTiles/Source/CollectionView/Sections/CollectionViewSection.swift
@@ -8,23 +8,77 @@
 
 import UIKit
 
+public typealias ItemSpacing = (horizontal: CGFloat, vertical: CGFloat)
+
 public protocol CollectionViewSection {
+
+    ///The minimum spacing between items in horizontal and vertical directions
+    var spacingBetweenItems: ItemSpacing { get }
+
+    ///The edges Insets for border spacing in this section
+    var sectionInsets: UIEdgeInsets { get }
+
+    ///Number of Items in this section
     var numberOfItems: Int { get }
+
     func registerCells(in collectionView: UICollectionView)
+
+    // MARK: - Configuration
 
     func collectionViewCell(
         at indexPath: IndexPath,
         on collectionView: UICollectionView
     ) -> UICollectionViewCell
+
     func viewForSupplementaryElement(
         kind: String,
         at indexPath: IndexPath,
         on collectionView: UICollectionView
     ) -> UICollectionReusableView
+
+    // MARK: - Layout
+
     func sizeForItem(
         at indexPath: IndexPath,
         on collectionView: UICollectionView,
         layout: UICollectionViewLayout
     ) -> CGSize
+
+    func sectionBorderEdges(
+        at section: Int,
+        on collectionView: UICollectionView,
+        layout: UICollectionViewLayout) -> UIEdgeInsets
+
+    func minimumVerticalItemSpacing(
+        at section: Int,
+        on collectionView: UICollectionView,
+        layout: UICollectionViewLayout) -> CGFloat
+
+    func minimumHorizontalItemSpacing(
+        at section: Int,
+        on collectionView: UICollectionView,
+        layout: UICollectionViewLayout) -> CGFloat
+
+    // MARK: - Actions
     func didSelectItem(at indexPath: IndexPath, on collectionView: UICollectionView)
+}
+
+extension CollectionViewSection {
+    public func sectionBorderEdges(at section: Int,
+                                   on collectionView: UICollectionView,
+                                   layout: UICollectionViewLayout) -> UIEdgeInsets {
+        return sectionInsets
+    }
+
+    public func minimumVerticalItemSpacing(at section: Int,
+                                           on collectionView: UICollectionView,
+                                           layout: UICollectionViewLayout) -> CGFloat {
+        return spacingBetweenItems.vertical
+    }
+
+    public func minimumHorizontalItemSpacing(at section: Int,
+                                             on collectionView: UICollectionView,
+                                             layout: UICollectionViewLayout) -> CGFloat {
+        return spacingBetweenItems.horizontal
+    }
 }

--- a/BricksAndTiles/Source/CollectionView/Sections/GridCollectionSection.swift
+++ b/BricksAndTiles/Source/CollectionView/Sections/GridCollectionSection.swift
@@ -1,26 +1,29 @@
 //
-//  StaticCollectionSection.swift
+//  GridCollectionSection.swift
 //  BricksAndTiles
 //
-//  Created by Pedro M. Zaroni on 30/07/20.
-//  Copyright © 2020 mugbug. All rights reserved.
+//  Created by Tulio Bazan on 24/09/20.
+//  Copyright © 2020 TucoBZ. All rights reserved.
 //
 
 import UIKit
 
-public final class StaticCollectionSection: CollectionViewSection {
+public final class GridCollectionSection: CollectionViewSection {
 
-    public var spacingBetweenItems: ItemSpacing
-    public var sectionInsets: UIEdgeInsets
+    public let spacingBetweenItems: ItemSpacing
+    public let sectionInsets: UIEdgeInsets
 
+    private let numberOfItemsPerRow: UInt
     private var cellBuilders: [CollectionViewCellBuilder]
 
     public init(cellBuilders: [CollectionViewCellBuilder],
-                spacingBetweenItems: ItemSpacing,
-                sectionInsets: UIEdgeInsets) {
+                numberOfItemsPerRow: UInt,
+                sectionInsets: UIEdgeInsets,
+                spacingBetweenItems: ItemSpacing) {
         self.cellBuilders = cellBuilders
-        self.spacingBetweenItems = spacingBetweenItems
+        self.numberOfItemsPerRow = numberOfItemsPerRow
         self.sectionInsets = sectionInsets
+        self.spacingBetweenItems = spacingBetweenItems
     }
 
     public var numberOfItems: Int {
@@ -56,7 +59,27 @@ public final class StaticCollectionSection: CollectionViewSection {
     public func sizeForItem(at indexPath: IndexPath,
                             on collectionView: UICollectionView,
                             layout: UICollectionViewLayout) -> CGSize {
-        return self.row(at: indexPath).cellSize(collectionSize: collectionView.bounds.size)
+
+        let cellSize = self.row(at: indexPath).cellSize(collectionSize: collectionView.bounds.size)
+
+        let insetsHorizontalSpacing = sectionInsets.left + sectionInsets.right
+        let paddingSpace =  spacingBetweenItems.horizontal * (CGFloat(numberOfItemsPerRow) + 1)
+        let availableWidth = collectionView.frame.width - paddingSpace - insetsHorizontalSpacing
+        let widthPerItem = availableWidth / CGFloat(numberOfItemsPerRow)
+
+        return CGSize(width: widthPerItem, height: widthPerItem * cellSize.height / cellSize.width)
+    }
+
+    public func minimumVerticalItemSpacing(at section: Int,
+                                           on collectionView: UICollectionView,
+                                           layout: UICollectionViewLayout) -> CGFloat {
+        return spacingBetweenItems.vertical - 1
+    }
+
+    public func minimumHorizontalItemSpacing(at section: Int,
+                                             on collectionView: UICollectionView,
+                                             layout: UICollectionViewLayout) -> CGFloat {
+        return spacingBetweenItems.horizontal - 1
     }
 
     public func didSelectItem(at indexPath: IndexPath, on collectionView: UICollectionView) {

--- a/Example/ExampleList/Entity/ExampleType.swift
+++ b/Example/ExampleList/Entity/ExampleType.swift
@@ -12,6 +12,7 @@ enum ExampleType: String, CaseIterable {
     case singleSelection = "Single selection"
     case horizontalList = "Horizontal List"
     case collectionView = "Static Collection"
+    case gridColletion = "Grid Collection"
 
     var title: String {
         switch self {
@@ -23,7 +24,7 @@ enum ExampleType: String, CaseIterable {
             return "Song of the Day"
         case .horizontalList:
             return "Songfy"
-        case .collectionView:
+        case .collectionView, .gridColletion:
             return "Available albums"
         }
     }

--- a/Example/ExampleList/ExampleListPresenter.swift
+++ b/Example/ExampleList/ExampleListPresenter.swift
@@ -11,6 +11,7 @@ protocol ExampleListViewDelegate: AnyObject {
     func showDraggableExample()
     func showCollectionExample()
     func showFactoryExample()
+    func showGridColletionExample()
 }
 
 class ExampleListPresenter {
@@ -23,6 +24,8 @@ class ExampleListPresenter {
             view?.showDraggableExample()
         case .collectionView:
             view?.showCollectionExample()
+        case .gridColletion:
+            view?.showGridColletionExample()
         default:
             view?.showExample(forType: type, isEditable: false)
         }

--- a/Example/ExampleList/ExampleListViewController.swift
+++ b/Example/ExampleList/ExampleListViewController.swift
@@ -61,6 +61,11 @@ extension ExampleListViewController: ExampleListViewDelegate {
         self.navigationController?.pushViewController(view, animated: true)
     }
 
+    func showGridColletionExample() {
+        let view = CollectionViewGridExampleController()
+        self.navigationController?.pushViewController(view, animated: true)
+    }
+
     func showFactoryExample() {
         let view = MeetupFactoryViewController()
         self.navigationController?.pushViewController(view, animated: true)

--- a/Example/Examples/CollectionViewExample/HorizontalListFactory.swift
+++ b/Example/Examples/CollectionViewExample/HorizontalListFactory.swift
@@ -16,10 +16,14 @@ struct HorizontalListFactory {
 
     func make() -> [CollectionViewSection] {
         let section = StaticCollectionSection(
-            cellBuilders: cellBuilders()
+            cellBuilders: cellBuilders(),
+            spacingBetweenItems: (5.0, 5.0),
+            sectionInsets: .zero
         )
         let section2 = StaticCollectionSection(
-            cellBuilders: cellBuilders()
+            cellBuilders: cellBuilders(),
+            spacingBetweenItems: (5.0, 5.0),
+            sectionInsets: UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
         )
         return [section, section2]
     }
@@ -27,7 +31,6 @@ struct HorizontalListFactory {
     func cellBuilders() -> [CollectionViewCellBuilder] {
         return availableImages().map {
             HorizontalCellBuilder(imageName: $0, cellSize: cellSize)
-
         }
     }
 

--- a/Example/Examples/CollectionViewExample/HorizontalListFactory.swift
+++ b/Example/Examples/CollectionViewExample/HorizontalListFactory.swift
@@ -17,12 +17,12 @@ struct HorizontalListFactory {
     func make() -> [CollectionViewSection] {
         let section = StaticCollectionSection(
             cellBuilders: cellBuilders(),
-            spacingBetweenItems: (5.0, 5.0),
+            spacingBetweenItems: (horizontal: 5.0, vertical: 5.0),
             sectionInsets: .zero
         )
         let section2 = StaticCollectionSection(
             cellBuilders: cellBuilders(),
-            spacingBetweenItems: (5.0, 5.0),
+            spacingBetweenItems: (horizontal: 5.0, vertical: 5.0),
             sectionInsets: UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
         )
         return [section, section2]

--- a/Example/Examples/CollectionViewGridExample/CollectionViewGridExampleController.swift
+++ b/Example/Examples/CollectionViewGridExample/CollectionViewGridExampleController.swift
@@ -1,0 +1,67 @@
+//
+//  CollectionViewGridExampleController.swift
+//  Example
+//
+//  Created by Tulio Bazan on 24/09/20.
+//  Copyright © 2020 TucoBZ. All rights reserved.
+//
+
+import UIKit
+import ViewCodeHelper
+import BricksAndTiles
+
+final class CollectionViewGridExampleController: UIViewController {
+
+    var dataSource: CollectionViewDataSource?
+
+    lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: flowLayout()
+        )
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.backgroundColor = .clear
+        return collectionView
+    }()
+
+    private func flowLayout() -> UICollectionViewFlowLayout {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        return layout
+    }
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        buildView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension CollectionViewGridExampleController: ViewCodeProtocol {
+    func setupHierarchy() {
+        view.addSubviewWithConstraints(subview: collectionView)
+    }
+
+    func setupConstraints() {}
+
+    func additionalSetup() {
+        title = ExampleType.gridColletion.title
+
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemBackground
+        }
+
+        let factory = GridListFactory(cellSize: cellSize)
+        self.dataSource = CollectionViewDataSource(
+            sections: factory.make(),
+            collectionView: collectionView
+        )
+    }
+
+    func cellSize(collectionSize: CGSize) -> CGSize {
+        return CGSize(width: 50, height: 50)
+    }
+}

--- a/Example/Examples/CollectionViewGridExample/GridListFactory.swift
+++ b/Example/Examples/CollectionViewGridExample/GridListFactory.swift
@@ -1,0 +1,61 @@
+//
+//  GridListFactory.swift
+//  Example
+//
+//  Created by Tulio Bazan on 24/09/20.
+//  Copyright © 2020 TucoBZ. All rights reserved.
+//
+
+import UIKit
+import BricksAndTiles
+import ViewCodeHelper
+
+struct GridListFactory {
+
+    var cellSize: (CGSize) -> CGSize
+
+    var sectionInsets: UIEdgeInsets = UIEdgeInsets(top: 8.0,
+                                                   left: 8.0,
+                                                   bottom: 8.0,
+                                                   right: 8.0)
+
+    func make() -> [CollectionViewSection] {
+        let section = GridCollectionSection(
+            cellBuilders: cellBuilders(),
+            numberOfItemsPerRow: 2,
+            sectionInsets: sectionInsets,
+            spacingBetweenItems: (8.0, 8.0)
+        )
+        let section2 = GridCollectionSection(
+            cellBuilders: cellBuilders(),
+            numberOfItemsPerRow: 3,
+            sectionInsets: sectionInsets,
+            spacingBetweenItems: (8.0, 8.0)
+        )
+        let section3 = GridCollectionSection(
+            cellBuilders: cellBuilders(),
+            numberOfItemsPerRow: 1,
+            sectionInsets: sectionInsets,
+            spacingBetweenItems: (8.0, 8.0)
+        )
+        return [section, section2, section3]
+    }
+
+    func cellBuilders() -> [CollectionViewCellBuilder] {
+        return availableImages().map {
+            HorizontalCellBuilder(imageName: $0, cellSize: cellSize)
+        }
+    }
+
+    private func availableImages() -> [String] {
+        return [
+            "iron-wine",
+            "lumineers",
+            "pink-floyd",
+            "lumineers-2",
+            "cage",
+            "iron-wine-2",
+            "ff"
+        ]
+    }
+}

--- a/Example/Examples/CollectionViewGridExample/GridListFactory.swift
+++ b/Example/Examples/CollectionViewGridExample/GridListFactory.swift
@@ -24,19 +24,19 @@ struct GridListFactory {
             cellBuilders: cellBuilders(),
             numberOfItemsPerRow: 2,
             sectionInsets: sectionInsets,
-            spacingBetweenItems: (8.0, 8.0)
+            spacingBetweenItems: (horizontal: 8.0, vertical: 8.0)
         )
         let section2 = GridCollectionSection(
             cellBuilders: cellBuilders(),
             numberOfItemsPerRow: 3,
             sectionInsets: sectionInsets,
-            spacingBetweenItems: (8.0, 8.0)
+            spacingBetweenItems: (horizontal: 8.0, vertical: 8.0)
         )
         let section3 = GridCollectionSection(
             cellBuilders: cellBuilders(),
             numberOfItemsPerRow: 1,
             sectionInsets: sectionInsets,
-            spacingBetweenItems: (8.0, 8.0)
+            spacingBetweenItems: (horizontal: 8.0, vertical: 8.0)
         )
         return [section, section2, section3]
     }


### PR DESCRIPTION
Description
===

This add a new kind of `CollectionViewSection` for `CollectionViewDataSource`, the `GridCollectionSection`. 

You can adapt you cell giving it the number of rows you want in that section, and `GridCollectionSection` will calculate the appropriate size for your cell to fill the space. It guarantee the aspectRatio from your `cellSize`

![Simulator Screen Shot - iPhone Xʀ iOS 13 6 - 2020-10-01 at 18 55 54](https://user-images.githubusercontent.com/6715785/94867559-d76dfa80-0417-11eb-83e4-12a23557309b.png)
.

Some Changes
===

I needed to add some more `UICollectionViewDelegateFlowLayout` functions into `CollectionViewDataSource` to be able to calculate the space between cells. Now other `CollectionViewSection` will need to add some more info to adapt too.

I add an example to how use it too.